### PR TITLE
align functions with camelcase in #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+#ide files
+.vscode

--- a/src/PropCheck.jl
+++ b/src/PropCheck.jl
@@ -95,13 +95,13 @@ function isample(x, shrink=shrink)
 end
 
 """
-    isample(x::AbstractRange[, shrink=shrinkTowards(first(x))]) -> AbstractIntegrated
+    isample(x::AbstractRange[, shrink=shrinktowards(first(x))]) -> AbstractIntegrated
 
 A convenience constructor for creating an integrated shrinker.
 
 Trees created by this shrink towards the first element of the range by default.
 """
-function isample(x::AbstractRange, shrink=shrinkTowards(first(x)))
+function isample(x::AbstractRange, shrink=shrinktowards(first(x)))
     gen = Generator{eltype(x)}(rng -> rand(rng, x))
     IntegratedRange(x, gen, shrink)
 end

--- a/src/checking.jl
+++ b/src/checking.jl
@@ -17,7 +17,7 @@ function check(p, i::AbstractIntegrated{T}, rng::AbstractRNG=Random.default_rng(
                   ntests::Int=numTests[], show_initial=true, transform=identity) where T
     gen = freeze(i)
     genAs = [ generate(rng, gen) for _ in 1:ntests ]
-    res = findCounterexample(p, genAs; show_initial)
+    res = findcounterexample(p, genAs; show_initial)
     res === nothing && return true
     @debug res
     entry = last(res)
@@ -66,7 +66,7 @@ struct CheckingError
     msg::String
 end
 
-function findCounterexample(f, trees::Vector; show_initial=true)
+function findcounterexample(f, trees::Vector; show_initial=true)
     function _f(tree)
         try
             ((!f ∘ root)(tree), tree, nothing)

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -9,7 +9,7 @@ Generator{T}(g) where T = Generator{T,typeof(g)}(g)
 Generator(el::T) where T = Generator{T}((rng)->generate(rng, el))
 Generator(::Type{T}) where T = Generator{T}((rng)->generate(rng, T))
 function Generator(x::Union)
-    types = getSubtypes(x)
+    types = getsubtypes(x)
     Generator{x}() do rng
         generate(rng, rand(rng, types))::x
     end

--- a/src/integrated.jl
+++ b/src/integrated.jl
@@ -93,7 +93,7 @@ function Integrated(el::Tree{T}) where T
 end
 
 function integratorType(u::Union)
-    types = getSubtypes(u)
+    types = getsubtypes(u)
     Union{(Tree{T} for T in types)...}
 end
 integratorType(::Type{T}) where T = Tree{T}
@@ -551,7 +551,7 @@ dependent(g::Generator{T,F}) where {T,F} = Integrated{T,F}(g.gen)
 Maps `f` lazily over all elements in `i`, producing an `AbstractIntegrated` generating the mapped values.
 """
 function PropCheck.map(f::F, gen::AbstractIntegrated{T}) where {T, F}
-    rettypes = Base.promote_op(f, unpackTreeUnion(T)...)
+    rettypes = Base.promote_op(f, unpacktreeunion(T)...)
     mapType = integratorType(rettypes)
     function genF(rng)
         val = generate(rng, freeze(gen))
@@ -561,10 +561,10 @@ function PropCheck.map(f::F, gen::AbstractIntegrated{T}) where {T, F}
     dependent(Generator{mapType}(genF))
 end
 
-unpackTreeUnion(::Type{Tree{T}}) where T = (T,)
-function unpackTreeUnion(::Type{T}) where T
+unpacktreeunion(::Type{Tree{T}}) where T = (T,)
+function unpacktreeunion(::Type{T}) where T
     !(T isa Union) && return (T,)
-    (unpackTreeUnion(T.a)..., unpackTreeUnion(T.b)...)
+    (unpacktreeunion(T.a)..., unpacktreeunion(T.b)...)
 end
 
 # we are Applicative with this

--- a/src/manual.jl
+++ b/src/manual.jl
@@ -9,27 +9,27 @@ generate(rng, m::Manual) = generate(rng, m.gen)
 drops(root::Vector) = (deleteat!(deepcopy(root), i) for i in eachindex(root))
 
 # create all tuples with all identity, except for one place which we shrink
-allFuncs(elShrink, root) = (( i == idx ? elShrink : (x -> [x]) for i in eachindex(root) ) for idx in eachindex(root))
+allfuncs(elShrink, root) = (( i == idx ? elShrink : (x -> [x]) for i in eachindex(root) ) for idx in eachindex(root))
 
 # apply the shrinking functions and filter unsuccessful shrinks
-shrunkEls(elShrink, root) = ifilter((x -> !(any(isempty, x) || all(==(root), x))),
-                    ((f(x) for (f,x) in zip(funcs, root)) for funcs in allFuncs(elShrink, root)))
+shrunkels(elShrink, root) = ifilter((x -> !(any(isempty, x) || all(==(root), x))),
+                    ((f(x) for (f,x) in zip(funcs, root)) for funcs in allfuncs(elShrink, root)))
 
-getProd(a, ::Type{<:Tuple}) = a
-getProd(a, ::Type{<:Vector}) = [a...]
+getprod(a, ::Type{<:Tuple}) = a
+getprod(a, ::Type{<:Vector}) = [a...]
 # we have a number of shrink results, take the product of all for all shrink combinations
-prods(elShrink, root::T) where T = flatten((getProd(p, T) for p in iproduct(shrunks...)) for shrunks in shrunkEls(elShrink, root))
+prods(elShrink, root::T) where T = flatten((getprod(p, T) for p in iproduct(shrunks...)) for shrunks in shrunkels(elShrink, root))
 
 # finally, filter out productions that resulted back in the original root for efficiency
 shrinks(elShrink, root) = (ifilter(!=(root), prods(elShrink, root)))
 
-function mList(genLen::Manual{I}, genA::Manual{T}) where {T, I <: Union{Base.BitInteger,Bool}}
+function mlist(genLen::Manual{I}, genA::Manual{T}) where {T, I <: Union{Base.BitInteger,Bool}}
     gen(rng) = T[ generate(rng, genA)::T for _ in 1:generate(rng, genLen)::I ]
     shrink(a) = uniqueitr(flatten((drops(a), shrinks(genA.shrink, a))))
     Manual(Generator{Vector{T}}(gen), shrink)
 end
 
-function repeatUntil(pred, ma)
+function repeatuntil(pred, ma)
     while true
         el = ma()
         pred(el) && return el
@@ -37,7 +37,7 @@ function repeatUntil(pred, ma)
 end
 
 function Base.filter(pred, genA::Manual{T}) where T
-    gen(rng) = repeatUntil(pred, () -> generate(rng, genA))
+    gen(rng) = repeatuntil(pred, () -> generate(rng, genA))
     shrink_(a) = flatten(pred(x) ? (x,) : shrink_(x) for x in genA.shrink(a))
     Manual(Generator{T}(gen), shrink_)
 end

--- a/src/shrinkers.jl
+++ b/src/shrinkers.jl
@@ -259,19 +259,19 @@ function shrink(r::T) where T <: AbstractRange
 end
 
 #######
-# shrinkTowards
+# shrinktowards
 ######
 
 """
-    shrinkTowards(to::T) -> (x::T -> T[...])
+    shrinktowards(to::T) -> (x::T -> T[...])
 
 Constructs a shrinker function that shrinks given values towards `to`.
 """
-function shrinkTowards end
+function shrinktowards end
 
 half(x::Real) = div(x, 0x2)
 half(x::Char) = Char(half(Int32(x)))
-function shrinkTowards(to::T) where T <: Union{Char, Real}
+function shrinktowards(to::T) where T <: Union{Char, Real}
     function (x::T)
         ret = T[]
         to == x && return ret
@@ -286,7 +286,7 @@ function shrinkTowards(to::T) where T <: Union{Char, Real}
     end
 end
 
-function shrinkTowards(to::T) where T <: AbstractFloat
+function shrinktowards(to::T) where T <: AbstractFloat
     function (x::T)
         ret = T[]
         to == x && return ret
@@ -303,7 +303,7 @@ function shrinkTowards(to::T) where T <: AbstractFloat
     end
 end
 
-shrinkTowards(to::Bool) = function (x::Bool)
+shrinktowards(to::Bool) = function (x::Bool)
     to == x && return Bool[]
     !to && x && return [false]
     to && !x && return Bool[]

--- a/src/util.jl
+++ b/src/util.jl
@@ -14,8 +14,8 @@ macro constfield(ex::Expr)
     end
 end
 
-function getSubtypes(T=Any)::Vector{DataType}
-    T isa Union && return getSubUnions!(DataType[], T)
+function getsubtypes(T=Any)::Vector{DataType}
+    T isa Union && return getsubunions!(DataType[], T)
     subs = subtypes(T)
     ret = filter(isconcretetype, subs)
     filter!(isabstracttype, subs)
@@ -31,11 +31,11 @@ function getSubtypes(T=Any)::Vector{DataType}
     ret
 end
 
-function getSubUnions!(cache, T)
+function getsubunions!(cache, T)
     if !(T isa Union)
         push!(cache, T)
     else
         push!(cache, T.a)
-        getSubUnions!(cache, T.b)
+        getsubunions!(cache, T.b)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 
 using PropCheck
-using PropCheck: getSubtypes, numTests, Tree
+using PropCheck: getsubtypes, numTests, Tree
 const PC = PropCheck
 
 using RequiredInterfaces: RequiredInterfaces
@@ -116,7 +116,7 @@ function assembleInf(T)
     end
 end
 
-const numTypes = union(getSubtypes(Integer), getSubtypes(AbstractFloat))
+const numTypes = union(getsubtypes(Integer), getsubtypes(AbstractFloat))
 
 @time @testset "All Tests" begin
     @testset "Interfaces" begin
@@ -127,7 +127,7 @@ const numTypes = union(getSubtypes(Integer), getSubtypes(AbstractFloat))
         num_ival = PC.IntegratedVal{PC.Tree{Number}}
         @test RI.check_interface_implemented(PC.ExtentIntegrated, num_ival)
     end
-    @testset "Tear $T & reassemble, floating point generators" for T in getSubtypes(Base.IEEEFloat)
+    @testset "Tear $T & reassemble, floating point generators" for T in getsubtypes(Base.IEEEFloat)
         @testset "assembleInf" begin
             assembleInf(T)
         end
@@ -145,7 +145,7 @@ const numTypes = union(getSubtypes(Integer), getSubtypes(AbstractFloat))
         end
     end
     @testset "Integer generators" begin
-        @testset for T in (getSubtypes(Base.BitSigned))
+        @testset for T in (getsubtypes(Base.BitSigned))
             @test check(>=(zero(T)), PC.iposint(T))
             @test check(<(zero(T)), PC.inegint(T))
         end
@@ -283,7 +283,7 @@ const numTypes = union(getSubtypes(Integer), getSubtypes(AbstractFloat))
         # The value will only be generated exactly once
         @test check(valgen) do v
             gen = PC.IntegratedOnce(v)
-            v == root(generate(gen)) && nothing == generate(gen)
+            v == root(generate(gen)) && isnothing(generate(gen))
         end
     end
     @testset "IntegratedFiniteIterator" begin


### PR DESCRIPTION
- There are 3 broken tests, which I don't know how to fix, or identify from the compiler message 
<img width="317" alt="Screenshot 2024-01-29 at 02 13 08" src="https://github.com/Seelengrab/PropCheck.jl/assets/46971368/7dacfaf7-6a22-42c8-9b62-2ed95d774323">

- I wanted to suggest functions like mList~> mlist  to be manuallist instead since abbreviations are also not recommended

```
- conciseness is valued, but avoid abbreviation ([indexin](https://docs.julialang.org/en/v1/base/collections/#Base.indexin) rather than indxin) as it becomes difficult to remember whether and how particular words are abbreviated.
```
